### PR TITLE
Fix repl mode so that all exits run stop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,8 +53,11 @@ function convertArgs(args) {
  */
 /* istanbul ignore next */
 function REPL(broker) {
+	vorpal.find("exit").remove() //vorpal vorpal-commons.js command, fails to run .stop() on exit
 	vorpal
 		.command("q", "Exit application")
+		.alias("quit")
+		.alias("exit")
 		.action((args, done) => {
 			broker.stop().then(() => process.exit(0));
 			done();


### PR DESCRIPTION
Fixes repl mode so we alias exit (after removing it from vorpal dependency exit which doesn't call stop()

-- Note, ctrl-C still quits before calling stop()