### PR TITLE
vorpal dependency event for exit (Ctrl-C/SIGINT)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ function convertArgs(args) {
 /* istanbul ignore next */
 function REPL(broker) {
 	vorpal.find("exit").remove() //vorpal vorpal-commons.js command, fails to run .stop() on exit
+	vorpal.on("vorpal_exit", () => { broker.stop().then(() => process.exit(0) }) //vorpal exit event (Ctrl-C)
 	vorpal
 		.command("q", "Exit application")
 		.alias("quit")


### PR DESCRIPTION
vorpal exits without stopping broker in REPL