### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ const registerCommands 	= require("./commands");
  */
 /* istanbul ignore next */
 function REPL(broker, customCommands) {
+	vorpal.isCommandArgKeyPairNormalized = false; // Switch off unix-like key value pair normalization
+	
 	vorpal.find("exit").remove(); //vorpal vorpal-commons.js command, fails to run .stop() on exit
 
 	vorpal.on("vorpal_exit", () => {


### PR DESCRIPTION
Switched off unix-like key value pair normalization in Vorpal.
Otherwise parameters that include 'key=value' pairs enclosed in parentheses will be split up.
Example:
--filter "opt1=true and (opt2=true or opt3=false)"