### PR TITLE
show service version if it is 0

### DIFF
--- a/src/commands/services.js
+++ b/src/commands/services.js
@@ -58,7 +58,7 @@ module.exports = function(vorpal, broker) {
 
 				data.push([
 					item.name,
-					(item.version || item.version === 0) ? item.version : "-",
+					item.version != null ? item.version : "-",
 					item.available ? chalk.bgGreen.white( "   OK   ") : chalk.bgRed.white.bold(" FAILED "),
 					item.actionCount,
 					item.eventCount,


### PR DESCRIPTION
Related to https://github.com/moleculerjs/moleculer/pull/415.

Show the service version instead of `-` if version is 0.

```
mol $ services
╔═══════════════╤═════════╤══════════╤═════════╤════════╤═══════╗
║ Service       │ Version │    State │ Actions │ Events │ Nodes ║
╟───────────────┼─────────┼──────────┼─────────┼────────┼───────╢
║ $node         │       - │    OK    │       6 │      0 │ 1     ║
║ api           │       1 │    OK    │       0 │      0 │ 1     ║
║ configuration │       0 │    OK    │       6 │      0 │ 1     ║
║ docs          │       1 │    OK    │       1 │      0 │ 1     ║
╚═══════════════╧═════════╧══════════╧═════════╧════════╧═══════╝
```